### PR TITLE
Support Windows file paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wwbd",
-  "version": "2022.0.0",
+  "version": "2022.0.1",
   "publisher": "brettcannon",
   "displayName": "WWBD",
   "description": "What Would Brett Do for Python environments?",

--- a/python-src/wwbd/__main__.py
+++ b/python-src/wwbd/__main__.py
@@ -1,6 +1,5 @@
 import argparse
 import json
-import os
 import pathlib
 
 from . import venv as wwbd_venv
@@ -14,9 +13,11 @@ def main(argv):
     python_path = wwbd_venv.create(args.workspace)
     requirements_file = wwbd_venv.install_requirements(python_path, args.workspace)
 
+    # Make sure to send POSIX file paths, else JSON.parse() will choke on
+    # Windows file paths.
     details = {
-        "executable": os.fsdecode(python_path),
-        "requirementsFile": os.fsdecode(requirements_file) if requirements_file else None,
+        "executable": python_path.as_posix(),
+        "requirementsFile": requirements_file.as_posix() if requirements_file else None,
     }
 
     print("<JSON>")

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -5,7 +5,7 @@ import * as path from "node:path";
 import * as vscode from "vscode";
 import * as pvsc from "./pvsc";
 
-const jsonTagRegex = /<JSON>\n(?<json>.+)\n<\/JSON>/;
+const jsonTagRegex = /<JSON>\r?\n(?<json>.+)\r?\n<\/JSON>/;
 
 const outputChannel = vscode.window.createOutputChannel("WWBD");
 

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -143,14 +143,31 @@ suite("Unit Tests", () => {
       requirementsFile: "requirements.txt",
     };
 
-    const goodOutput = `${badOutput}\n<JSON>\n${JSON.stringify(
-      payload
-    )}\n</JSON>\nOther unexpected stuff at shutdown ...`;
+    const goodOutput = `${badOutput}
+<JSON>
+${JSON.stringify(payload)}
+</JSON>
+Other unexpected stuff at shutdown ...`;
 
     const actual = wwbd.parseOutput(goodOutput);
 
     assert.strictEqual(actual?.executable, payload.executable);
     assert.strictEqual(actual?.requirementsFile, payload.requirementsFile);
+  });
+
+  test("Parse output with a Windows file path", () => {
+    const output = `<JSON>
+{"executable": "c:/Users/brcan/Testing/Some Python scratch space/.venv/Scripts/python.exe", "requirementsFile": null}
+</JSON>`;
+
+    const actual = wwbd.parseOutput(output);
+
+    assert.strictEqual(
+      actual?.executable,
+      "c:/Users/brcan/Testing/Some Python scratch space/.venv/Scripts/python.exe"
+    );
+
+    assert.strictEqual(actual.requirementsFile, null);
   });
 });
 


### PR DESCRIPTION
`JSON.parse()` chokes on Windows file paths (e.g. `c:\\src`), so force paths to POSIX-style.

Fixes #14